### PR TITLE
Linear op mode support

### DIFF
--- a/ftc-robotcontroller/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/BasicVisionSample.java
+++ b/ftc-robotcontroller/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/BasicVisionSample.java
@@ -54,7 +54,7 @@ public class BasicVisionSample extends VisionOpMode {
 
         //Enable extensions. Use what you need.
         enableExtension(Extensions.BEACON);     //Beacon detection
-        enableExtension(Extensions.QR);         //QR Code detection
+        //enableExtension(Extensions.QR);         //QR Code detection
         enableExtension(Extensions.ROTATION);   //Automatic screen rotation correction
 
         //You can do this for certain phones which switch red and blue

--- a/ftc-robotcontroller/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/FtcOpModeRegister.java
+++ b/ftc-robotcontroller/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/FtcOpModeRegister.java
@@ -56,6 +56,7 @@ public class FtcOpModeRegister implements OpModeRegister {
      */
         manager.register("NullOp", NullOp.class);
         manager.register("Basic Vision Sample", BasicVisionSample.class);
+        manager.register("Linear Vision Sample", LinearVisionSample.class);
         manager.register("Manual Vision Sample", ManualVisionSample.class);
     }
 }

--- a/ftc-robotcontroller/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/LinearVisionSample.java
+++ b/ftc-robotcontroller/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/LinearVisionSample.java
@@ -55,7 +55,7 @@ public class LinearVisionSample extends LinearVisionOpMode {
 
         //Enable extensions. Use what you need.
         enableExtension(Extensions.BEACON);     //Beacon detection
-        enableExtension(Extensions.QR);         //QR Code detection
+        //enableExtension(Extensions.QR);         //QR Code detection
         enableExtension(Extensions.ROTATION);   //Automatic screen rotation correction
 
         //You can do this for certain phones which switch red and blue
@@ -83,7 +83,7 @@ public class LinearVisionSample extends LinearVisionOpMode {
             telemetry.addData("Frame Rate", fps.getFPSString() + " FPS");
             telemetry.addData("Frame Size", "Width: " + width + " Height: " + height);
 
-            // Wait for Threader hardware cycle to allow other processes to run
+            // Wait for a hardware cycle to allow other processes to run
             waitOneFullHardwareCycle();
         }
     }

--- a/ftc-robotcontroller/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/LinearVisionSample.java
+++ b/ftc-robotcontroller/src/main/java/com/qualcomm/ftcrobotcontroller/opmodes/LinearVisionSample.java
@@ -1,0 +1,90 @@
+/* Copyright (c) 2014, 2015 Qualcomm Technologies Inc
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted (subject to the limitations in the disclaimer below) provided that
+the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list
+of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+Neither the name of Qualcomm Technologies Inc nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS
+LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
+
+package com.qualcomm.ftcrobotcontroller.opmodes;
+
+import org.lasarobotics.vision.android.Cameras;
+import org.lasarobotics.vision.opmode.LinearVisionOpMode;
+import org.opencv.core.Size;
+
+/**
+ * TeleOp Mode
+ * <p/>
+ * Enables control of the robot via the gamepad
+ */
+public class LinearVisionSample extends LinearVisionOpMode {
+
+    @Override
+    public void runOpMode() throws InterruptedException {
+        //Wait for vision to initialize - this should be the first thing you do
+        waitForVisionStart();
+
+        //Set the camera used for detection
+        this.setCamera(Cameras.SECONDARY);
+        //Set the frame size
+        //Larger = sometimes more accurate, but also much slower
+        this.setFrameSize(new Size(900, 900));
+
+        //Enable extensions. Use what you need.
+        enableExtension(Extensions.BEACON);     //Beacon detection
+        enableExtension(Extensions.QR);         //QR Code detection
+        enableExtension(Extensions.ROTATION);   //Automatic screen rotation correction
+
+        //You can do this for certain phones which switch red and blue
+        //It will rotate the display and detection by 180 degrees, making it upright
+        //rotation.setUnbiasedOrientation(ScreenOrientation.LANDSCAPE_WEST);
+
+        //You can also do this when using the secondary camera
+        //Sometimes it is necessary to ensure upright rotation
+        rotation.setRotationInversion(true);
+
+        //Wait for the match to begin
+        waitForStart();
+
+        //Main loop
+        //Camera frames and OpenCV analysis will be delivered to this method as quickly as possible
+        //This loop will exit once the opmode is closed
+        while (opModeIsActive()) {
+            //Log a few things
+            telemetry.addData("Beacon Color", beacon.getAnalysis().getColorString());
+            telemetry.addData("Beacon Location (Center)", beacon.getAnalysis().getLocationString());
+            telemetry.addData("Beacon Confidence", beacon.getAnalysis().getConfidenceString());
+            telemetry.addData("QR Error", qr.getErrorReason());
+            telemetry.addData("QR String", qr.getText());
+            telemetry.addData("Rotation Compensation", rotation.getRotationAngle());
+            telemetry.addData("Frame Rate", fps.getFPSString() + " FPS");
+            telemetry.addData("Frame Size", "Width: " + width + " Height: " + height);
+
+            // Wait for Threader hardware cycle to allow other processes to run
+            waitOneFullHardwareCycle();
+        }
+    }
+}

--- a/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/LinearVisionOpMode.java
+++ b/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/LinearVisionOpMode.java
@@ -1,10 +1,155 @@
 package org.lasarobotics.vision.opmode;
 
+import com.qualcomm.robotcore.util.ElapsedTime;
+import com.qualcomm.robotcore.util.RobotLog;
+
 /**
- * Linear version of the Vision OpMode - NOT YET SUPPORTED
+ * Linear version of the Vision OpMode
+ * This includes code from the FIRST library (C) Qualcomm as of 1/23/2016
  */
-public class LinearVisionOpMode {
+public abstract class LinearVisionOpMode extends VisionOpMode {
+    private Threader threader = null;
+    private Thread thread = null;
+    private ElapsedTime timer = new ElapsedTime();
+    private volatile boolean opModeStarted = false;
+
     public LinearVisionOpMode() {
-        throw new RuntimeException("Linear OpModes are not yet supported. Please use VisionOpMode.");
+
+    }
+
+    public abstract void runOpMode() throws InterruptedException;
+
+    public final void waitForVisionStart() throws InterruptedException {
+        while (!this.isInitialized()) {
+            synchronized (this) {
+                this.wait();
+            }
+        }
+    }
+
+    public synchronized void waitForStart() throws InterruptedException {
+        while (!this.opModeStarted) {
+            synchronized (this) {
+                this.wait();
+            }
+        }
+    }
+
+    public void waitOneFullHardwareCycle() throws InterruptedException {
+        this.waitForNextHardwareCycle();
+        Thread.sleep(1L);
+        this.waitForNextHardwareCycle();
+    }
+
+    public void waitForNextHardwareCycle() throws InterruptedException {
+        synchronized (this) {
+            this.wait();
+        }
+    }
+
+    public void sleep(long milliseconds) throws InterruptedException {
+        Thread.sleep(milliseconds);
+    }
+
+    public boolean opModeIsActive() {
+        return this.opModeStarted;
+    }
+
+    @Override
+    public final void init() {
+        super.init();
+        this.threader = new Threader(this);
+        this.thread = new Thread(this.threader, "Linear OpMode Helper");
+        this.thread.start();
+    }
+
+    @Override
+    public final void init_loop() {
+        this.notifyOrThrowError();
+    }
+
+    @Override
+    public final void start() {
+        this.opModeStarted = true;
+        synchronized (this) {
+            this.notifyAll();
+        }
+    }
+
+    @Override
+    public final void loop() {
+        super.loop();
+        this.notifyOrThrowError();
+    }
+
+    @Override
+    public final void stop() {
+        super.stop();
+        this.opModeStarted = false;
+        if (!this.threader.isReady()) {
+            this.thread.interrupt();
+        }
+
+        this.timer.reset();
+
+        while (!this.threader.isReady() && this.timer.time() < 0.5D) {
+            Thread.yield();
+        }
+
+        if (!this.threader.isReady()) {
+            RobotLog.e("*****************************************************************");
+            RobotLog.e("User Linear Op Mode took too long to exit; emergency killing app.");
+            RobotLog.e("Possible infinite loop in user code?");
+            RobotLog.e("*****************************************************************");
+            System.exit(-1);
+        }
+    }
+
+    private void notifyOrThrowError() {
+        if (this.threader.hasError()) {
+            throw this.threader.getLastError();
+        } else {
+            synchronized (this) {
+                this.notifyAll();
+            }
+        }
+    }
+
+    private static class Threader implements Runnable {
+        private final LinearVisionOpMode opModeReference;
+        private RuntimeException lastError = null;
+        private boolean ready = false;
+
+        public Threader(LinearVisionOpMode var1) {
+            this.opModeReference = var1;
+        }
+
+        public void run() {
+            this.lastError = null;
+            this.ready = false;
+
+            try {
+                this.opModeReference.runOpMode();
+            } catch (InterruptedException var6) {
+                RobotLog.d("LinearOpMode received an Interrupted Exception; shutting down this linear op mode");
+            } catch (RuntimeException var7) {
+                this.lastError = var7;
+            } finally {
+                this.ready = true;
+            }
+
+        }
+
+        public boolean hasError() {
+            return this.lastError != null;
+        }
+
+        public RuntimeException getLastError() {
+            return this.lastError;
+        }
+
+        public boolean isReady() {
+            return this.ready;
+        }
     }
 }

--- a/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpMode.java
+++ b/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpMode.java
@@ -27,7 +27,7 @@ public abstract class VisionOpMode extends VisionOpModeCore {
      */
 
     private int extensions = 0;
-    private boolean initialized = false;
+    private boolean extensionsInitialized = false;
 
     public VisionOpMode() {
         super();
@@ -44,7 +44,7 @@ public abstract class VisionOpMode extends VisionOpModeCore {
 
     protected void enableExtension(Extensions extension) {
         //Don't initialize extension if we haven't ever called init() yet
-        if (initialized)
+        if (extensionsInitialized)
             extension.instance.init(this);
 
         extensions = extensions | extension.id;
@@ -64,7 +64,7 @@ public abstract class VisionOpMode extends VisionOpModeCore {
             if (isEnabled(extension))
                 extension.instance.init(this);
 
-        initialized = true;
+        extensionsInitialized = true;
     }
 
     @Override

--- a/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpModeCore.java
+++ b/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpModeCore.java
@@ -44,10 +44,13 @@ abstract class VisionOpModeCore extends OpMode implements CameraBridgeViewBase.C
             }
         }
     };
-
     public int width, height;
     public FPS fps;
     public Sensors sensors;
+
+    protected boolean isInitialized() {
+        return initialized;
+    }
 
     public void setCamera(Cameras camera) {
         if (openCVCamera == null)


### PR DESCRIPTION
Adds support for a linear op mode (sample included). All users have to do is add `waitForVisionStart()` at the beginning of their `runOpMode()` and extend `LinearVisionOpMode` instead of `LinearOpMode`.
