### PR TITLE
Fix the critical second-init issue

### DIFF
--- a/ftc-cameratest/src/main/java/com/lasarobotics/tests/camera/CameraTestVisionOpMode.java
+++ b/ftc-cameratest/src/main/java/com/lasarobotics/tests/camera/CameraTestVisionOpMode.java
@@ -47,17 +47,6 @@ public class CameraTestVisionOpMode extends TestableVisionOpMode {
         //Try them all and see what works!
         beacon.setAnalysisMethod(Beacon.AnalysisMethod.FAST);
 
-        //Set analysis boundary
-        //You should comment this to use the entire screen and uncomment only if
-        //you want faster analysis at the cost of not using the entire frame.
-        //This is also particularly useful if you know approximately where the beacon is
-        //as this will eliminate parts of the frame which may cause problems
-        //This will not work on some methods, such as COMPLEX
-        Rectangle bounds = new Rectangle(new Point(width / 2, height / 2), width - 200, 200);
-        beacon.setAnalysisBounds(bounds);
-        //Or you can just use the entire screen
-        //beacon.setAnalysisBounds(new Rectangle(0, 0, height, width));
-
         //Debug drawing
         //Enable this only if you're running test app - otherwise, you should turn it off
         //(Although it doesn't harm anything if you leave it on, only slows down processing a tad)
@@ -73,6 +62,21 @@ public class CameraTestVisionOpMode extends TestableVisionOpMode {
 
     @Override
     public Mat frame(Mat rgba, Mat gray) {
+        /*
+          We set the Analysis boundary in the frame loop just in case we couldn't get it
+          during init(). This happens when another app is using OpenCV simulataneously.
+         */
+        //Set analysis boundary
+        //You should comment this to use the entire screen and uncomment only if
+        //you want faster analysis at the cost of not using the entire frame.
+        //This is also particularly useful if you know approximately where the beacon is
+        //as this will eliminate parts of the frame which may cause problems
+        //This will not work on some methods, such as COMPLEX
+        Rectangle bounds = new Rectangle(new Point(width / 2, height / 2), width - 200, 200);
+        beacon.setAnalysisBounds(bounds);
+        //Or you can just use the entire screen
+        //beacon.setAnalysisBounds(new Rectangle(0, 0, height, width));
+
         //Run all extensions, then get matrices
         rgba = super.frame(rgba, gray);
         Imgproc.cvtColor(rgba, gray, Imgproc.COLOR_RGBA2GRAY);

--- a/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpMode.java
+++ b/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpMode.java
@@ -77,6 +77,7 @@ public abstract class VisionOpMode extends VisionOpModeCore {
 
     @Override
     public Mat frame(Mat rgba, Mat gray) {
+
         for (Extensions extension : Extensions.values())
             if (isEnabled(extension)) {
                 //Pipe the rgba of the previous point into the gray of the next

--- a/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpModeCore.java
+++ b/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpModeCore.java
@@ -32,7 +32,9 @@ abstract class VisionOpModeCore extends OpMode implements CameraBridgeViewBase.C
     public Sensors sensors;
 
     public VisionOpModeCore() {
-
+        initialized = false;
+        openCVInitialized = false;
+        openCVCamera = null;
     }
 
     boolean isInitialized() {

--- a/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpModeCore.java
+++ b/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpModeCore.java
@@ -33,7 +33,6 @@ abstract class VisionOpModeCore extends OpMode implements CameraBridgeViewBase.C
 
     public VisionOpModeCore() {
         initialized = false;
-        openCVInitialized = false;
         openCVCamera = null;
     }
 
@@ -76,6 +75,12 @@ abstract class VisionOpModeCore extends OpMode implements CameraBridgeViewBase.C
 
         width = openCVCamera.getFrameWidth();
         height = openCVCamera.getFrameHeight();
+        if (width == 0 || height == 0) {
+            Log.e("FTCVision", "OpenCV Camera failed to initialize width and height properties on startup.\r\n" +
+                    "This is generally okay, but if you use width or height during init() you may\r\n" +
+                    "run into a problem.");
+        }
+
         return new Size(width, height);
     }
 
@@ -190,6 +195,9 @@ abstract class VisionOpModeCore extends OpMode implements CameraBridgeViewBase.C
             openCVCamera.disableView();
             openCVCamera.disconnectCamera();
         }
+
+        initialized = false;
+        openCVCamera = null;
 
         super.stop();
     }


### PR DESCRIPTION
Previously, when running two apps that used OpenCV at the same time or when when stopping one opmode and opening another, the camera would not activate properly and the entire app would hang. The issue was fixed with a revelation in the form of a dream, one hot cup of coffee, and 4 lines of code.
