### PR TITLE
Clean sensors thread shutdown

### DIFF
--- a/ftc-cameratest/src/main/java/com/lasarobotics/tests/camera/CameraTestVisionOpMode.java
+++ b/ftc-cameratest/src/main/java/com/lasarobotics/tests/camera/CameraTestVisionOpMode.java
@@ -61,6 +61,11 @@ public class CameraTestVisionOpMode extends TestableVisionOpMode {
     }
 
     @Override
+    public void stop() {
+        super.stop();
+    }
+
+    @Override
     public Mat frame(Mat rgba, Mat gray) {
         /*
           We set the Analysis boundary in the frame loop just in case we couldn't get it

--- a/ftc-visionlib/src/main/java/org/lasarobotics/vision/android/Sensors.java
+++ b/ftc-visionlib/src/main/java/org/lasarobotics/vision/android/Sensors.java
@@ -37,7 +37,6 @@ public final class Sensors implements SensorEventListener {
         mSensorManager = (SensorManager) Util.getContext().getSystemService(Context.SENSOR_SERVICE);
         mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
         mMagneticField = mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
-        activated = false;
         resume();
     }
 
@@ -47,19 +46,20 @@ public final class Sensors implements SensorEventListener {
     public void resume() {
         if (activated)
             return;
+        activated = true;
         mSensorManager.registerListener(this, mAccelerometer, READ_SPEED);
         mSensorManager.registerListener(this, mMagneticField, READ_SPEED);
-        activated = true;
     }
 
     /**
      * Pause sensor reading
      */
     public void stop() {
-        if (!activated)
-            return;
+        //if (!activated)
+        //    return;
+        mSensorManager.unregisterListener(this, mAccelerometer);
+        mSensorManager.unregisterListener(this, mMagneticField);
         activated = false;
-        mSensorManager.unregisterListener(this);
     }
 
     /**

--- a/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionEnabledActivity.java
+++ b/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionEnabledActivity.java
@@ -83,7 +83,7 @@ public abstract class VisionEnabledActivity extends Activity implements CameraBr
         super.onPause();
         if (openCVCamera != null)
             openCVCamera.disableView();
-        opMode.sensors.stop();
+        opMode.stop();
     }
 
     @Override
@@ -91,7 +91,7 @@ public abstract class VisionEnabledActivity extends Activity implements CameraBr
         super.onDestroy();
         if (openCVCamera != null)
             openCVCamera.disableView();
-        opMode.sensors.stop();
+        opMode.stop();
         this.finish();
     }
 
@@ -113,7 +113,5 @@ public abstract class VisionEnabledActivity extends Activity implements CameraBr
             Log.d("OpenCV", "OpenCV library found inside package. Using it!");
             openCVLoaderCallback.onManagerConnected(LoaderCallbackInterface.SUCCESS);
         }
-
-        opMode.sensors.resume();
     }
 }

--- a/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpModeCore.java
+++ b/ftc-visionlib/src/main/java/org/lasarobotics/vision/opmode/VisionOpModeCore.java
@@ -196,6 +196,9 @@ abstract class VisionOpModeCore extends OpMode implements CameraBridgeViewBase.C
             openCVCamera.disconnectCamera();
         }
 
+        if (sensors != null)
+            sensors.stop();
+
         initialized = false;
         openCVCamera = null;
 


### PR DESCRIPTION
Before: sensors thread would continue in background even when app is closed
After: sensors thread quits cleanly when opmode or testing app exits
